### PR TITLE
Allow to have different constructors for clients

### DIFF
--- a/internal/test/server.go
+++ b/internal/test/server.go
@@ -48,23 +48,6 @@ func (s MockHTTPServer) ServeVersionedFailure(t *testing.T, path string, respons
 	s.serveVersion(t, path, 500, response)
 }
 
-// Close closes the server connection.
-func (s MockHTTPServer) Close() {
-	s.Server.Close()
-}
-
-// serve registers a path handler and writes to its response.
-func (s MockHTTPServer) serve(t *testing.T, version string, path string, statusCode int, response interface{}) {
-	s.mux.HandleFunc(
-		fmt.Sprintf("%v%v", version, path),
-		func(w http.ResponseWriter, r *http.Request) {
-			w.Header().Set("Content-Type", "application/json")
-			w.WriteHeader(statusCode)
-			fprint(t, w, response)
-		},
-	)
-}
-
 // serveUnversioned registers the unversioned route.
 func (s MockHTTPServer) serveUnversion(t *testing.T, path string, statusCode int, response interface{}) {
 	s.serve(t, "/synse", path, statusCode, response)
@@ -80,6 +63,23 @@ func (s MockHTTPServer) serveVersion(t *testing.T, path string, statusCode int, 
 			w.Header().Set("Content-Type", "application/json")
 			fprint(t, w, `{"version": "3.x.x", "api_version": "v3"}`)
 		})
+}
+
+// serve registers a path handler and writes to its response.
+func (s MockHTTPServer) serve(t *testing.T, version string, path string, statusCode int, response interface{}) {
+	s.mux.HandleFunc(
+		fmt.Sprintf("%v%v", version, path),
+		func(w http.ResponseWriter, r *http.Request) {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(statusCode)
+			fprint(t, w, response)
+		},
+	)
+}
+
+// Close closes the server connection.
+func (s MockHTTPServer) Close() {
+	s.Server.Close()
 }
 
 // fprint calls fmt.Fprint and validates its returned error.

--- a/synse/http.go
+++ b/synse/http.go
@@ -141,12 +141,15 @@ func (c *httpClient) setVersioned() (*resty.Client, error) {
 // check validates returned response from the Synse Server.
 func check(err error, errResp *Error) error {
 	if err != nil {
-		return errors.Wrap(err, "failed to validate response from synse server")
+		return errors.Wrap(err, "failed to make a request to synse server")
 	}
 
 	if *errResp != (Error{}) {
-		// FIXME - should we print out the full struct with its field names here.
-		return errors.Errorf("got an error response from synse server: %+v", errResp)
+		return errors.Errorf(
+			"got a %v error response from synse server at %v, saying %v, with context: %v",
+			errResp.HTTPCode, errResp.Timestamp, errResp.Description, errResp.Context,
+		)
+
 	}
 
 	return nil

--- a/synse/http.go
+++ b/synse/http.go
@@ -115,12 +115,7 @@ func (c *httpClient) Config() (*Config, error) {
 // getUnversioned performs a GET request against the Synse Server unversioned API.
 func (c *httpClient) getUnversioned(uri string, okScheme interface{}) error {
 	errScheme := new(Error)
-	client, err := c.setUnversioned()
-	if err != nil {
-		return errors.Wrap(err, "failed to set an unversioned host")
-	}
-
-	_, err = client.R().SetResult(okScheme).SetError(errScheme).Get(uri)
+	_, err := c.setUnversioned().R().SetResult(okScheme).SetError(errScheme).Get(uri)
 	return check(err, errScheme)
 }
 
@@ -137,8 +132,8 @@ func (c *httpClient) getVersioned(uri string, okScheme interface{}) error {
 }
 
 // setUnversioned returns a client that uses unversioned host URL.
-func (c *httpClient) setUnversioned() (*resty.Client, error) {
-	return c.client.SetHostURL(fmt.Sprintf("http://%s/synse/", c.options.Address)), nil
+func (c *httpClient) setUnversioned() *resty.Client {
+	return c.client.SetHostURL(fmt.Sprintf("http://%s/synse/", c.options.Address))
 }
 
 // setVersioned returns a client that uses versioned host URL.

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -11,7 +11,7 @@ import (
 func TestNewHTTPClient_NilConfig(t *testing.T) {
 	client, err := NewHTTPClient(nil)
 	assert.Nil(t, client)
-	assert.Error(t, err, "config shoud not be nil")
+	assert.Error(t, err)
 }
 
 func TestNewHTTPClient_NoAddress(t *testing.T) {
@@ -19,7 +19,7 @@ func TestNewHTTPClient_NoAddress(t *testing.T) {
 		Address: "",
 	})
 	assert.Nil(t, client)
-	assert.Error(t, err, "address shoud not be empty")
+	assert.Error(t, err)
 }
 
 func TestNewHTTPClient_ValidAddress(t *testing.T) {

--- a/synse/scheme.go
+++ b/synse/scheme.go
@@ -25,14 +25,14 @@ type Version struct {
 
 // Config describes a response for `/config` endpoint.
 type Config struct {
-	Logging    string           `json:"logging"`
 	Locale     string           `json:"locale"`
-	PrettyJSON bool             `json:"pretty_json"`
+	Logging    string           `json:"logging"`
 	Plugin     PluginOptions    `json:"plugin"`
 	Cache      CacheOptions     `json:"cache"`
 	GRPC       GRPCOptions      `json:"grpc"`
-	Metrics    MetricsOptions   `json:"metrics"`
 	Transport  TransportOptions `json:"transport"`
+	Metrics    MetricsOptions   `json:"metrics"`
+	PrettyJSON bool             `json:"pretty_json"`
 }
 
 // PluginOptions is the config options for plugin.

--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -1,8 +1,0 @@
-package synse
-
-// websocket.go implements a websocket client.
-
-// websocketClient implements a Websocket client.
-type websocketClient struct {
-	// TODO
-}


### PR DESCRIPTION
This PR allows users to have different constructors for clients, aiming to fix #7. It also does some refactoring and housekeeping stuff.