### PR TITLE
Remove version caching

### DIFF
--- a/examples/http.go
+++ b/examples/http.go
@@ -13,7 +13,7 @@ func main() {
 		Address: "localhost:5000",
 	}
 
-	client, err := synse.NewHTTPClient(config)
+	client, err := synse.NewHTTPClientV3(config)
 	fmt.Printf("%+v, %+v\n", client, err)
 
 	r1, err := client.Status()

--- a/synse/http.go
+++ b/synse/http.go
@@ -22,19 +22,6 @@ type httpClient struct {
 	apiVersion string
 }
 
-// NewHTTPClient returns a new instance of a http client.
-func NewHTTPClient(options *Options) (Client, error) {
-	client, err := createHTTPClient(options)
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to create a http client")
-	}
-
-	return &httpClient{
-		options: options,
-		client:  client,
-	}, nil
-}
-
 // NewHTTPClientV3 returns a new instance of a http client with API v3.
 func NewHTTPClientV3(options *Options) (Client, error) {
 	client, err := createHTTPClient(options)
@@ -318,26 +305,7 @@ func (c *httpClient) setUnversioned() *resty.Client {
 
 // setVersioned returns a client that uses versioned host URL.
 func (c *httpClient) setVersioned() (*resty.Client, error) {
-	err := c.cacheAPIVersion()
-	if err != nil {
-		return nil, errors.Wrap(err, "failed to cache api version")
-	}
-
 	return c.client.SetHostURL(fmt.Sprintf("http://%s/%s/", c.options.Address, c.apiVersion)), nil
-}
-
-// cacheAPIVersion caches the api version if not already.
-func (c *httpClient) cacheAPIVersion() error {
-	if c.apiVersion == "" {
-		client, err := c.Version()
-		if err != nil {
-			return errors.Wrap(err, "failed to get synse version for caching")
-		}
-
-		c.apiVersion = client.APIVersion
-	}
-
-	return nil
 }
 
 // check validates returned response from the Synse Server.

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -10,30 +10,30 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestNewHTTPClient_NilConfig(t *testing.T) {
-	client, err := NewHTTPClient(nil)
+func TestNewHTTPClientV3_NilConfig(t *testing.T) {
+	client, err := NewHTTPClientV3(nil)
 	assert.Nil(t, client)
 	assert.Error(t, err)
 }
 
-func TestNewHTTPClient_NoAddress(t *testing.T) {
-	client, err := NewHTTPClient(&Options{
+func TestNewHTTPClientV3_NoAddress(t *testing.T) {
+	client, err := NewHTTPClientV3(&Options{
 		Address: "",
 	})
 	assert.Nil(t, client)
 	assert.Error(t, err)
 }
 
-func TestNewHTTPClient_ValidAddress(t *testing.T) {
-	client, err := NewHTTPClient(&Options{
+func TestNewHTTPClientV3_ValidAddress(t *testing.T) {
+	client, err := NewHTTPClientV3(&Options{
 		Address: "localhost:5000",
 	})
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 }
 
-func TestNewHTTPClient_ValidAddressAndTimeout(t *testing.T) {
-	client, err := NewHTTPClient(&Options{
+func TestNewHTTPClientV3_ValidAddressAndTimeout(t *testing.T) {
+	client, err := NewHTTPClientV3(&Options{
 		Address: "localhost:5000",
 		Timeout: 3 * time.Second,
 	})
@@ -41,8 +41,8 @@ func TestNewHTTPClient_ValidAddressAndTimeout(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestNewHTTPClient_ValidRetry(t *testing.T) {
-	client, err := NewHTTPClient(&Options{
+func TestNewHTTPClientV3_ValidRetry(t *testing.T) {
+	client, err := NewHTTPClientV3(&Options{
 		Address: "localhost:5000",
 		Retry: RetryOptions{
 			Count:       3,
@@ -54,7 +54,7 @@ func TestNewHTTPClient_ValidRetry(t *testing.T) {
 	assert.NoError(t, err)
 }
 
-func TestHTTPClient_Unversioned_200(t *testing.T) {
+func TestHTTPClientV3_Unversioned_200(t *testing.T) {
 	tests := []struct {
 		path     string
 		in       string
@@ -89,7 +89,7 @@ func TestHTTPClient_Unversioned_200(t *testing.T) {
 	server := test.NewUnversionedHTTPServer()
 	defer server.Close()
 
-	client, err := NewHTTPClient(&Options{
+	client, err := NewHTTPClientV3(&Options{
 		Address: server.URL,
 	})
 	assert.NotNil(t, client)
@@ -114,7 +114,7 @@ func TestHTTPClient_Unversioned_200(t *testing.T) {
 	}
 }
 
-func TestHTTPClient_Unversioned_500(t *testing.T) {
+func TestHTTPClientV3_Unversioned_500(t *testing.T) {
 	tests := []struct {
 		path string
 	}{
@@ -125,7 +125,7 @@ func TestHTTPClient_Unversioned_500(t *testing.T) {
 	server := test.NewUnversionedHTTPServer()
 	defer server.Close()
 
-	client, err := NewHTTPClient(&Options{
+	client, err := NewHTTPClientV3(&Options{
 		Address: server.URL,
 	})
 	assert.NotNil(t, client)
@@ -894,7 +894,7 @@ func TestHTTPClient_Versioned_200(t *testing.T) { // nolint
 	server := test.NewVersionedHTTPServer()
 	defer server.Close()
 
-	client, err := NewHTTPClient(&Options{
+	client, err := NewHTTPClientV3(&Options{
 		Address: server.URL,
 	})
 	assert.NotNil(t, client)
@@ -950,7 +950,7 @@ func TestHTTPClient_Versioned_200(t *testing.T) { // nolint
 	}
 }
 
-func TestHTTPClient_Versioned_500(t *testing.T) { // nolint
+func TestHTTPClientV3_Versioned_500(t *testing.T) { // nolint
 	tests := []struct {
 		path string
 	}{
@@ -973,7 +973,7 @@ func TestHTTPClient_Versioned_500(t *testing.T) { // nolint
 	server := test.NewVersionedHTTPServer()
 	defer server.Close()
 
-	client, err := NewHTTPClient(&Options{
+	client, err := NewHTTPClientV3(&Options{
 		Address: server.URL,
 	})
 	assert.NotNil(t, client)


### PR DESCRIPTION
This fixes #13 by removing the version caching logic and using "v3" as the default version.