### PR TITLE
use uint for retry max count for consistency

### DIFF
--- a/synse/config.go
+++ b/synse/config.go
@@ -46,7 +46,7 @@ type WebSocketOptions struct {
 // value.
 type RetryOptions struct {
 	// Count specifies the number of retry attempts. Zero value means no retry.
-	Count int `default:"3"`
+	Count uint `default:"3"`
 
 	// WaitTime specifies the wait time before retrying request. It is
 	// increased after each attempt.

--- a/synse/http.go
+++ b/synse/http.go
@@ -60,7 +60,7 @@ func createHTTPClient(opts *Options) (*resty.Client, error) {
 	client := resty.New()
 	client = client.
 		SetTimeout(opts.HTTP.Timeout).
-		SetRetryCount(opts.HTTP.Retry.Count).
+		SetRetryCount(int(opts.HTTP.Retry.Count)).
 		SetRetryWaitTime(opts.HTTP.Retry.WaitTime).
 		SetRetryMaxWaitTime(opts.HTTP.Retry.MaxWaitTime)
 

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -46,7 +46,7 @@ func TestNewHTTPClientV3_defaults(t *testing.T) {
 
 	assert.Equal(t, "localhost:5000", client.GetOptions().Address)
 	assert.Equal(t, 2*time.Second, client.GetOptions().HTTP.Timeout)
-	assert.Equal(t, int(3), client.GetOptions().HTTP.Retry.Count)
+	assert.Equal(t, uint(3), client.GetOptions().HTTP.Retry.Count)
 	assert.Equal(t, 100*time.Millisecond, client.GetOptions().HTTP.Retry.WaitTime)
 	assert.Equal(t, 2*time.Second, client.GetOptions().HTTP.Retry.MaxWaitTime)
 	assert.Empty(t, client.GetOptions().TLS.CertFile)


### PR DESCRIPTION
Fix #44 