### PR TITLE
normalize annotations on scheme structs

### DIFF
--- a/synse/scheme/event.go
+++ b/synse/scheme/event.go
@@ -2,122 +2,122 @@ package scheme
 
 // EventMeta describes core elements in a event request/response scheme.
 type EventMeta struct {
-	ID    uint64 `json:"id" yaml:"id"`
-	Event string `json:"event" yaml:"event"`
+	ID    uint64 `json:"id" yaml:"id" mapstructure:"id"`
+	Event string `json:"event" yaml:"event" mapstructure:"event"`
 }
 
 // RequestStatus describes a scheme for request/status event.
 type RequestStatus struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestVersion describes a scheme for request/version event.
 type RequestVersion struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestConfig describes a scheme for request/config event.
 type RequestConfig struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestPlugins describes a scheme for request/plugin event, with no
 // plugin id being provided.
 type RequestPlugins struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestPlugin describes a scheme for request/plugin event.
 type RequestPlugin struct {
-	EventMeta
-	Data PluginData `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      PluginData `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // PluginData describes the data for request/plugin event.
 type PluginData struct {
-	Plugin string `json:"plugin"`
+	Plugin string `json:"plugin" yaml:"plugin" mapstructure:"plugin"`
 }
 
 // RequestPluginHealth describes a scheme for request/plugin_health event.
 type RequestPluginHealth struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestScan describes a scheme for request/scan event.
 type RequestScan struct {
-	EventMeta
-	Data ScanOptions `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      ScanOptions `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // RequestTags describes a scheme for request/tags event.
 type RequestTags struct {
-	EventMeta
-	Data TagsOptions `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      TagsOptions `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // RequestInfo describes a scheme for request/info event.
 type RequestInfo struct {
-	EventMeta
-	Data DeviceData `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      DeviceData `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // DeviceData describes the data for response/info event.
 type DeviceData struct {
-	Device string `json:"device"`
+	Device string `json:"device" yaml:"device" mapstructure:"device"`
 }
 
 // RequestRead describes a scheme for request/read event.
 type RequestRead struct {
-	EventMeta
-	Data ReadOptions `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      ReadOptions `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // RequestReadDevice describes a scheme for request/read_device event.
 type RequestReadDevice struct {
-	EventMeta
-	Data ReadDeviceData `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      ReadDeviceData `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // ReadDeviceData describes the data for request/read_device event.
 type ReadDeviceData struct {
-	ID string `json:"id"`
-	ReadOptions
+	ID          string `json:"id" yaml:"id" mapstructure:"id"`
+	ReadOptions `mapstructure:",squash"`
 }
 
 // RequestReadCache describes a scheme for request/read_cache event.
 type RequestReadCache struct {
-	EventMeta
-	Data ReadCacheOptions `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      ReadCacheOptions `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // RequestWrite describes a scheme for request/write_async and
 // request/write_sync event.
 type RequestWrite struct {
-	EventMeta
-	Data RequestWriteData `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      RequestWriteData `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // RequestWriteData describes the data for request/write_async and
 // request/write_sync event.
 type RequestWriteData struct {
-	ID      string      `json:"id"`
-	Payload []WriteData `json:"payload"`
+	ID      string      `json:"id" yaml:"id" mapstructure:"id"`
+	Payload []WriteData `json:"payload" yaml:"payload" mapstructure:"payload"`
 }
 
 // RequestTransactions describes a scheme for request/transaction event with no
 // transaction id being provided.
 type RequestTransactions struct {
-	EventMeta
+	EventMeta `mapstructure:",squash"`
 }
 
 // RequestTransaction describes a scheme for request/transaction event.
 type RequestTransaction struct {
-	EventMeta
-	Data WriteData `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      WriteData `json:"data" yaml:"data" mapstructure:"data"`
 }
 
 // Response describes a generic response scheme.
 type Response struct {
-	EventMeta
-	Data interface{} `json:"data"`
+	EventMeta `mapstructure:",squash"`
+	Data      interface{} `json:"data" yaml:"data" mapstructure:"data"`
 }

--- a/synse/scheme/read.go
+++ b/synse/scheme/read.go
@@ -13,6 +13,6 @@ type Read struct {
 
 // ReadOptions describes the query parameters for `/read` endpoint.
 type ReadOptions struct {
-	NS   string   `json:"ns" yaml:"ns"`
-	Tags []string `json:"tags" yaml:"tags"`
+	NS   string   `json:"ns" yaml:"ns" mapstructure:"ns"`
+	Tags []string `json:"tags" yaml:"tags" mapstructure:"tags"`
 }

--- a/synse/scheme/readcache.go
+++ b/synse/scheme/readcache.go
@@ -2,6 +2,6 @@ package scheme
 
 // ReadCacheOptions describes the query parameters for `/readcache` endpoint.
 type ReadCacheOptions struct {
-	Start string
-	End   string
+	Start string `json:"start" yaml:"start" mapstructure:"start"`
+	End   string `json:"end" yaml:"end" mapstructure:"end"`
 }

--- a/synse/scheme/scan.go
+++ b/synse/scheme/scan.go
@@ -11,8 +11,8 @@ type Scan struct {
 
 // ScanOptions describes the query parameters for `/scan` endpoint.
 type ScanOptions struct {
-	NS    string
-	Tags  []string
-	Force bool
-	Sort  []string
+	NS    string   `json:"ns" yaml:"ns" mapstructure:"ns"`
+	Tags  []string `json:"tags" yaml:"tags" mapstructure:"tags"`
+	Force bool     `json:"force" yaml:"force" mapstructure:"force"`
+	Sort  []string `json:"sort" yaml:"sort" mapstructure:"sort"`
 }

--- a/synse/scheme/write.go
+++ b/synse/scheme/write.go
@@ -11,7 +11,7 @@ type Write struct {
 // WriteData describes an unit in the POST body for the `/write` endpoint. This
 // can also be used in a websocket request event payload.
 type WriteData struct {
-	Transaction string      `json:"transaction" yaml:"transaction"`
-	Action      string      `json:"action" yaml:"action"`
-	Data        interface{} `json:"data" yaml:"data"`
+	Transaction string      `json:"transaction" yaml:"transaction" mapstructure:"transaction"`
+	Action      string      `json:"action" yaml:"action" mapstructure:"action"`
+	Data        interface{} `json:"data" yaml:"data" mapstructure:"data"`
 }


### PR DESCRIPTION
fixes #47 by having all `json`, `yaml` and `mapstructure` annotations in all fields.