### PR TITLE
update client readcache interface to pass data through a channel

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,13 +4,11 @@ go 1.12
 
 require (
 	github.com/creasty/defaults v1.3.0
-	github.com/davecgh/go-spew v1.1.1
+	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/gorilla/websocket v1.4.0
 	github.com/mitchellh/mapstructure v1.1.2
 	github.com/pkg/errors v0.8.1
-	github.com/pmezard/go-difflib v1.0.0
 	github.com/stretchr/testify v1.3.0
-	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e
-	golang.org/x/text v0.3.0
+	golang.org/x/net v0.0.0-20190119204137-ed066c81e75e // indirect
 	gopkg.in/resty.v1 v1.11.0
 )

--- a/go.sum
+++ b/go.sum
@@ -17,6 +17,5 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 golang.org/x/net v0.0.0-20181220203305-927f97764cc3/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e h1:MDa3fSUp6MdYHouVmCCNz/zaH2a6CRcxY3VhT/K3C5Q=
 golang.org/x/net v0.0.0-20190119204137-ed066c81e75e/go.mod h1:mL1N/T3taQHkDXs73rZJwtUhF3w3ftmwwsq0BUmARs4=
-golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 gopkg.in/resty.v1 v1.11.0 h1:z5nqGs/W/h91PLOc+WZefPj8rRZe8Ctlgxg/AtbJ+NE=
 gopkg.in/resty.v1 v1.11.0/go.mod h1:mDo4pnntr5jdWRML875a/NmxYqAlA73dVijT2AXvQQo=

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -5,10 +5,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/stretchr/testify/assert"
 	"github.com/vapor-ware/synse-client-go/internal/test"
 	"github.com/vapor-ware/synse-client-go/synse/scheme"
-
-	"github.com/stretchr/testify/assert"
 )
 
 func TestNewHTTPClientV3_NilConfig(t *testing.T) {
@@ -1193,10 +1192,36 @@ func TestHTTPClientV3_ReadCache_200(t *testing.T) {
 	assert.NoError(t, err)
 
 	opts := scheme.ReadCacheOptions{}
-	resp, err := client.ReadCache(opts)
-	assert.NotNil(t, resp)
-	assert.NoError(t, err)
-	assert.Equal(t, expected, resp)
+	readings := make(chan *scheme.Read, 1)
+
+	go func() {
+		err := client.ReadCache(opts, readings)
+		assert.NoError(t, err)
+	}()
+
+	var results []*scheme.Read
+
+	for {
+		var done bool
+		select {
+		case r, open := <-readings:
+			if !open {
+				done = true
+				break
+			}
+			results = append(results, r)
+
+		case <-time.After(2 * time.Second):
+			// If the test does not complete after 2s, error.
+			t.Fatal("timeout: failed getting readcache data from channel")
+		}
+
+		if done {
+			break
+		}
+	}
+
+	assert.Equal(t, expected, results)
 }
 
 func TestHTTPClientV3_ReadCache_500(t *testing.T) {
@@ -1220,9 +1245,35 @@ func TestHTTPClientV3_ReadCache_500(t *testing.T) {
 	assert.NoError(t, err)
 
 	opts := scheme.ReadCacheOptions{}
-	resp, err := client.ReadCache(opts)
-	assert.Nil(t, resp)
-	assert.Error(t, err)
+	readings := make(chan *scheme.Read, 1)
+
+	go func() {
+		err := client.ReadCache(opts, readings)
+		assert.Error(t, err)
+	}()
+
+	var results []*scheme.Read
+
+	for {
+		var done bool
+		select {
+		case r, open := <-readings:
+			if !open {
+				done = true
+				break
+			}
+			results = append(results, r)
+
+		case <-time.After(2 * time.Second):
+			// If the test does not complete after 2s, error.
+			t.Fatal("timeout: failed getting readcache data from channel")
+		}
+
+		if done {
+			break
+		}
+	}
+	assert.Empty(t, results)
 }
 
 func TestHTTPClientV3_WriteAsync_200(t *testing.T) {
@@ -1280,7 +1331,7 @@ func TestHTTPClientV3_WriteAsync_200(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 
-	opts := []scheme.WriteData{}
+	var opts []scheme.WriteData
 	resp, err := client.WriteAsync("1b714cf2-cc56-5c36-9741-fd6a483b5f10", opts)
 	assert.NotNil(t, resp)
 	assert.NoError(t, err)
@@ -1307,7 +1358,7 @@ func TestHTTPClientV3_WriteAsync_500(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 
-	opts := []scheme.WriteData{}
+	var opts []scheme.WriteData
 	resp, err := client.WriteAsync("1b714cf2-cc56-5c36-9741-fd6a483b5f10", opts)
 	assert.Nil(t, resp)
 	assert.Error(t, err)
@@ -1358,7 +1409,7 @@ func TestHTTPClientV3_WriteSync_200(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 
-	opts := []scheme.WriteData{}
+	var opts []scheme.WriteData
 	resp, err := client.WriteSync("1b714cf2-cc56-5c36-9741-fd6a483b5f10", opts)
 	assert.NotNil(t, resp)
 	assert.NoError(t, err)
@@ -1385,7 +1436,7 @@ func TestHTTPClientV3_WriteSync_500(t *testing.T) {
 	assert.NotNil(t, client)
 	assert.NoError(t, err)
 
-	opts := []scheme.WriteData{}
+	var opts []scheme.WriteData
 	resp, err := client.WriteSync("1b714cf2-cc56-5c36-9741-fd6a483b5f10", opts)
 	assert.Nil(t, resp)
 	assert.Error(t, err)

--- a/synse/synse.go
+++ b/synse/synse.go
@@ -52,7 +52,7 @@ type Client interface {
 	ReadDevice(string, scheme.ReadOptions) ([]*scheme.Read, error)
 
 	// ReadCache returns stream reading data from the registered plugins.
-	ReadCache(scheme.ReadCacheOptions) ([]*scheme.Read, error)
+	ReadCache(scheme.ReadCacheOptions, chan<- *scheme.Read) error
 
 	// WriteAsync writes data to a device, in an asynchronous manner.
 	WriteAsync(string, []scheme.WriteData) ([]*scheme.Write, error)


### PR DESCRIPTION
this should fix #59

it updates the client interface so the readcache data is passed back via a channel - this makes things more memory efficient for the receiver, since we don't necessarily need to load the entire blob of (potentially many) readings all at once.