### PR TITLE
add initial integration tests for websocket client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,12 +37,20 @@ test:  ## Run unit tests
 	@ # Note: this requires go1.10+ in order to do multi-package coverage reports
 	go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
 
-.PHONY: test-integration
-test-integration:  ## Run integration tests
+.PHONY: test-integration-http
+test-integration-http:  ## Run integration tests for http client
 	-docker-compose -f compose/server.yml rm -fsv
 	docker-compose -f compose/server.yml up -d
 	sleep 6
-	go test -race -cover -run Integration ./... || (docker-compose -f compose/server.yml stop; exit 1)
+	go test -race -cover -run IntegrationHTTP ./... || (docker-compose -f compose/server.yml stop; exit 1)
+	docker-compose -f compose/server.yml down
+
+.PHONY: test-integration-websocket
+test-integration-websocket:  ## Run integration tests for websocket client
+	-docker-compose -f compose/server.yml rm -fsv
+	docker-compose -f compose/server.yml up -d
+	sleep 6
+	go test -race -cover -run IntegrationWebSocket ./... || (docker-compose -f compose/server.yml stop; exit 1)
 	docker-compose -f compose/server.yml down
 
 .PHONY: version
@@ -51,6 +59,6 @@ version:  ## Print the version of the client
 
 .PHONY: help
 help:  ## Print usage information
-	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-16s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
+	@awk 'BEGIN {FS = ":.*?## "} /^[a-zA-Z_-]+:.*?## / {printf "\033[36m%-26s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST) | sort
 
 .DEFAULT_GOAL := help

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,10 @@ lint:  ## Lint project source files
 	golint -set_exit_status ./...
 
 .PHONY: test
-test:  ## Run unit tests
+test: test-unit test-integration-http test-integration-websocket  ## Run all tests
+
+.PHONY: test-unit
+test-unit:  ## Run unit tests
 	@ # Note: this requires go1.10+ in order to do multi-package coverage reports
 	go test -short -race -coverprofile=coverage.out -covermode=atomic ./...
 

--- a/synse/event.go
+++ b/synse/event.go
@@ -45,6 +45,9 @@ const (
 	// requestWriteSync describes the request/write_sync event.
 	requestWriteSync = "request/write_sync"
 
+	// requestTransactions describes the request/transactions event.
+	requestTransactions = "request/transactions"
+
 	// requestTransaction describes the request/transaction event.
 	requestTransaction = "request/transaction"
 
@@ -84,8 +87,11 @@ const (
 	// responseWriteSync describes the response/write_sync event.
 	responseWriteSync = "response/write_sync"
 
-	// responseTransaction describes the response/transaction event.
-	responseTransaction = "response/transaction"
+	// responseTransactionList describes the response/transaction_list event.
+	responseTransactionList = "response/transaction_list"
+
+	// responseTransactionInfo describes the response/transaction_info event.
+	responseTransactionInfo = "response/transaction_info"
 
 	// responseError describes the response/error event.
 	responseError = "response/error"

--- a/synse/event.go
+++ b/synse/event.go
@@ -15,6 +15,9 @@ const (
 	// requestPlugin describes the request/plugin event.
 	requestPlugin = "request/plugin"
 
+	// requestPlugins describes the request/plugins event.
+	requestPlugins = "request/plugins"
+
 	// requestPluginHealth describes the request/plugin_health event.
 	requestPluginHealth = "request/plugin_health"
 
@@ -54,8 +57,11 @@ const (
 	// responseConfig describes the response/config event.
 	responseConfig = "response/config"
 
-	// responsePlugin describes the response/plugin event.
-	responsePlugin = "response/plugin"
+	// responsePlugin describes the response/plugin_info event.
+	responsePlugin = "response/plugin_info"
+
+	// responsePluginSummary describes the response/plugin_summary event.
+	responsePluginSummary = "response/plugin_summary"
 
 	// responsePluginHealth describes the response/plugin_health event.
 	responsePluginHealth = "response/plugin_health"
@@ -64,7 +70,7 @@ const (
 	responseTags = "response/tags"
 
 	// responseDevice describes the response/device event.
-	responseDevice = "response/device"
+	responseDevice = "response/device_info"
 
 	// responseDeviceSummary describes the response/device_summary event.
 	responseDeviceSummary = "response/device_summary"

--- a/synse/http_integration_test.go
+++ b/synse/http_integration_test.go
@@ -8,7 +8,7 @@ import (
 	"github.com/vapor-ware/synse-client-go/synse/scheme"
 )
 
-func TestIntegration_Status(t *testing.T) {
+func TestIntegrationHTTP_Status(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -25,7 +25,7 @@ func TestIntegration_Status(t *testing.T) {
 	assert.NotEmpty(t, status.Timestamp)
 }
 
-func TestIntegration_Version(t *testing.T) {
+func TestIntegrationHTTP_Version(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -42,7 +42,7 @@ func TestIntegration_Version(t *testing.T) {
 	assert.Equal(t, "v3", version.APIVersion)
 }
 
-func TestIntegration_Config(t *testing.T) {
+func TestIntegrationHTTP_Config(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -67,7 +67,7 @@ func TestIntegration_Config(t *testing.T) {
 	assert.False(t, config.Metrics.Enabled)
 }
 
-func TestIntegration_Plugins(t *testing.T) {
+func TestIntegrationHTTP_Plugins(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -91,7 +91,7 @@ func TestIntegration_Plugins(t *testing.T) {
 	assert.True(t, plugin.Active)
 }
 
-func TestIntegration_PluginInfo(t *testing.T) {
+func TestIntegrationHTTP_PluginInfo(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -142,7 +142,7 @@ func TestIntegration_PluginInfo(t *testing.T) {
 	// assert.NotEmpty(t, writeCheck.Timestamp)
 }
 
-func TestIntegration_PluginHealth(t *testing.T) {
+func TestIntegrationHTTP_PluginHealth(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -164,7 +164,7 @@ func TestIntegration_PluginHealth(t *testing.T) {
 	assert.Equal(t, 0, health.Inactive)
 }
 
-func TestIntegration_Scan(t *testing.T) {
+func TestIntegrationHTTP_Scan(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -226,7 +226,7 @@ func TestIntegration_Scan(t *testing.T) {
 	assert.Equal(t, "system/type:led", ledDevice.Tags[2])
 }
 
-func TestIntegration_Tags(t *testing.T) {
+func TestIntegrationHTTP_Tags(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -246,7 +246,7 @@ func TestIntegration_Tags(t *testing.T) {
 	assert.Equal(t, "system/type:temperature", tags[2])
 }
 
-func TestIntegration_Info(t *testing.T) {
+func TestIntegrationHTTP_Info(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -288,7 +288,7 @@ func TestIntegration_Info(t *testing.T) {
 	assert.Equal(t, 0.0, colorOutput.ScalingFactor)
 }
 
-func TestIntegration_Read(t *testing.T) {
+func TestIntegrationHTTP_Read(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -330,7 +330,7 @@ func TestIntegration_Read(t *testing.T) {
 	}
 }
 
-func TestIntegration_ReadDevice(t *testing.T) {
+func TestIntegrationHTTP_ReadDevice(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -364,7 +364,7 @@ func TestIntegration_ReadDevice(t *testing.T) {
 	assert.Empty(t, colorRead.Context)
 }
 
-func TestIntegration_ReadCache(t *testing.T) {
+func TestIntegrationHTTP_ReadCache(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -422,7 +422,7 @@ func TestIntegration_ReadCache(t *testing.T) {
 	}
 }
 
-func TestIntegration_WriteAsync(t *testing.T) {
+func TestIntegrationHTTP_WriteAsync(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -458,7 +458,7 @@ func TestIntegration_WriteAsync(t *testing.T) {
 	assert.Equal(t, "30s", colorWrite.Timeout)
 }
 
-func TestIntegration_WriteSync(t *testing.T) {
+func TestIntegrationHTTP_WriteSync(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -500,7 +500,7 @@ func TestIntegration_WriteSync(t *testing.T) {
 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", colorWrite.Device)
 }
 
-func TestIntegration_Transaction(t *testing.T) {
+func TestIntegrationHTTP_Transaction(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}
@@ -530,7 +530,7 @@ func TestIntegration_Transaction(t *testing.T) {
 	}
 }
 
-func TestIntegration_TagsOptions(t *testing.T) {
+func TestIntegrationHTTP_TagsOptions(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping integration test")
 	}

--- a/synse/scheme/event.go
+++ b/synse/scheme/event.go
@@ -99,7 +99,7 @@ type RequestWrite struct {
 // RequestWriteData describes the data for request/write_async and
 // request/write_sync event.
 type RequestWriteData struct {
-	ID      string      `json:"id" yaml:"id" mapstructure:"id"`
+	Device  string      `json:"device" yaml:"device" mapstructure:"device"`
 	Payload []WriteData `json:"payload" yaml:"payload" mapstructure:"payload"`
 }
 

--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -175,7 +175,7 @@ func (c *websocketClient) Plugins() ([]*scheme.PluginMeta, error) {
 	req := scheme.RequestPlugins{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
-			Event: requestPlugin,
+			Event: requestPlugins,
 		},
 	}
 
@@ -521,6 +521,8 @@ func matchEvent(reqEvent string) string { // nolint
 		respEvent = responseConfig
 	case requestPlugin:
 		respEvent = responsePlugin
+	case requestPlugins:
+		respEvent = responsePluginSummary
 	case requestPluginHealth:
 		respEvent = responsePluginHealth
 	case requestScan:

--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -406,7 +406,7 @@ func (c *websocketClient) Transactions() ([]string, error) {
 	req := scheme.RequestTransactions{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
-			Event: requestTransaction,
+			Event: requestTransactions,
 		},
 	}
 
@@ -541,8 +541,10 @@ func matchEvent(reqEvent string) string { // nolint
 		respEvent = responseWriteSync
 	case requestWriteAsync:
 		respEvent = responseWriteAsync
+	case requestTransactions:
+		respEvent = responseTransactionList
 	case requestTransaction:
-		respEvent = responseTransaction
+		respEvent = responseTransactionInfo
 	default:
 		respEvent = ""
 	}

--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -271,14 +271,14 @@ func (c *websocketClient) Tags(opts scheme.TagsOptions) ([]string, error) {
 
 // Info returns the full set of meta info and capabilities for a specific
 // device.
-func (c *websocketClient) Info(id string) (*scheme.Info, error) {
+func (c *websocketClient) Info(device string) (*scheme.Info, error) {
 	req := scheme.RequestInfo{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
 			Event: requestInfo,
 		},
 		Data: scheme.DeviceData{
-			Device: id,
+			Device: device,
 		},
 	}
 
@@ -314,14 +314,14 @@ func (c *websocketClient) Read(opts scheme.ReadOptions) ([]*scheme.Read, error) 
 // ReadDevice returns data from a specific device.
 // It is the same as Read() where the label matches the device id tag
 // specified in ReadOptions.
-func (c *websocketClient) ReadDevice(id string) ([]*scheme.Read, error) {
+func (c *websocketClient) ReadDevice(device string) ([]*scheme.Read, error) {
 	req := scheme.RequestReadDevice{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
 			Event: requestReadDevice,
 		},
 		Data: scheme.ReadDeviceData{
-			Device: id,
+			Device: device,
 		},
 	}
 
@@ -358,14 +358,14 @@ func (c *websocketClient) ReadCache(opts scheme.ReadCacheOptions, out chan<- *sc
 }
 
 // WriteAsync writes data to a device, in an asynchronous manner.
-func (c *websocketClient) WriteAsync(id string, opts []scheme.WriteData) ([]*scheme.Write, error) {
+func (c *websocketClient) WriteAsync(device string, opts []scheme.WriteData) ([]*scheme.Write, error) {
 	req := scheme.RequestWrite{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
 			Event: requestWriteAsync,
 		},
 		Data: scheme.RequestWriteData{
-			ID:      id,
+			Device:  device,
 			Payload: opts,
 		},
 	}
@@ -380,14 +380,14 @@ func (c *websocketClient) WriteAsync(id string, opts []scheme.WriteData) ([]*sch
 }
 
 // WriteSync writes data to a device, waiting for the write to complete.
-func (c *websocketClient) WriteSync(id string, opts []scheme.WriteData) ([]*scheme.Transaction, error) {
+func (c *websocketClient) WriteSync(device string, opts []scheme.WriteData) ([]*scheme.Transaction, error) {
 	req := scheme.RequestWrite{
 		EventMeta: scheme.EventMeta{
 			ID:    c.addCounter(),
 			Event: requestWriteSync,
 		},
 		Data: scheme.RequestWriteData{
-			ID:      id,
+			Device:  device,
 			Payload: opts,
 		},
 	}

--- a/synse/websocket_integration_test.go
+++ b/synse/websocket_integration_test.go
@@ -1,0 +1,528 @@
+package synse
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/vapor-ware/synse-client-go/synse/scheme"
+)
+
+func TestIntegrationWebSocket_Status(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	status, err := client.Status()
+	assert.NoError(t, err)
+	assert.Equal(t, "ok", status.Status)
+	assert.NotEmpty(t, status.Timestamp)
+}
+
+func TestIntegrationWebSocket_Version(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	version, err := client.Version()
+	assert.NoError(t, err)
+	assert.NotEmpty(t, version.Version)
+	assert.Equal(t, "v3", version.APIVersion)
+}
+
+func TestIntegrationWebSocket_Config(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	config, err := client.Config()
+	assert.NoError(t, err)
+	assert.Equal(t, "debug", config.Logging)
+	assert.True(t, config.PrettyJSON)
+	assert.Equal(t, "en_US", config.Locale)
+	assert.Equal(t, 1, len(config.Plugin.TCP))
+	assert.Equal(t, "emulator:5001", config.Plugin.TCP[0])
+	assert.Equal(t, 0, len(config.Plugin.Unix))
+	assert.Equal(t, 180, config.Cache.Device.RebuildEvery)
+	assert.Equal(t, 300, config.Cache.Transaction.TTL)
+	assert.Equal(t, 3, config.GRPC.Timeout)
+	assert.False(t, config.Metrics.Enabled)
+}
+
+func TestIntegrationWebSocket_Plugins(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	plugins, err := client.Plugins()
+	assert.NoError(t, err)
+	assert.Equal(t, 1, len(plugins))
+
+	plugin := plugins[0]
+	assert.Equal(t, "emulator plugin", plugin.Name)
+	assert.Equal(t, "vaporio", plugin.Maintainer)
+	assert.Equal(t, "vaporio/emulator-plugin", plugin.Tag)
+	assert.Equal(t, "A plugin with emulated devices and data", plugin.Description)
+	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", plugin.ID)
+	assert.True(t, plugin.Active)
+}
+
+func TestIntegrationWebSocket_PluginInfo(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	plugin, err := client.Plugin("4032ffbe-80db-5aa5-b794-f35c88dff85c")
+	assert.NoError(t, err)
+	assert.Equal(t, "emulator plugin", plugin.Name)
+	assert.Equal(t, "vaporio", plugin.Maintainer)
+	assert.Equal(t, "vaporio/emulator-plugin", plugin.Tag)
+	assert.Equal(t, "A plugin with emulated devices and data", plugin.Description)
+	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", plugin.ID)
+	assert.True(t, plugin.Active)
+
+	assert.Equal(t, "emulator:5001", plugin.Network.Address)
+	assert.Equal(t, "tcp", plugin.Network.Protocol)
+	assert.NotEmpty(t, plugin.Version.PluginVersion)
+	assert.NotEmpty(t, plugin.Version.SDKVersion)
+	assert.NotEmpty(t, plugin.Version.BuildDate)
+	assert.NotEmpty(t, plugin.Version.GitCommit)
+	assert.NotEmpty(t, plugin.Version.GitTag)
+	assert.Equal(t, "amd64", plugin.Version.Arch)
+	assert.Equal(t, "linux", plugin.Version.OS)
+	assert.NotEmpty(t, plugin.Health.Timestamp)
+	assert.Equal(t, "OK", plugin.Health.Status)
+	assert.Equal(t, 2, len(plugin.Health.Checks))
+
+	readCheck := plugin.Health.Checks[0]
+	assert.Equal(t, "read queue health", readCheck.Name)
+	assert.Equal(t, "OK", readCheck.Status)
+	assert.Equal(t, "periodic", readCheck.Type)
+	assert.Empty(t, readCheck.Message)
+
+	writeCheck := plugin.Health.Checks[1]
+	assert.Equal(t, "write queue health", writeCheck.Name)
+	assert.Equal(t, "OK", writeCheck.Status)
+	assert.Equal(t, "periodic", writeCheck.Type)
+	assert.Empty(t, writeCheck.Message)
+
+	// NOTE - health check timestamp is not populated after at least 30s of
+	// deployment. that's a pretty long time so we won't check that for now.
+	// assert.NotEmpty(t, readCheck.Timestamp)
+	// assert.NotEmpty(t, writeCheck.Timestamp)
+}
+
+func TestIntegrationWebSocket_PluginHealth(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	health, err := client.PluginHealth()
+	assert.NoError(t, err)
+	assert.Equal(t, "healthy", health.Status)
+	assert.NotEmpty(t, health.Updated)
+	assert.Equal(t, 1, len(health.Healthy))
+	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", health.Healthy[0])
+	assert.Equal(t, 0, len(health.Unhealthy))
+	assert.Equal(t, 1, health.Active)
+	assert.Equal(t, 0, health.Inactive)
+}
+
+// FIXME - got a 500 error response from synse server at 2019-08-29T15:55:52Z,
+// saying An unexpected error occurred., with context: object of type
+// 'NoneType' has no len()
+// func TestIntegrationWebSocket_Scan(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	opts := scheme.ScanOptions{}
+// 	devices, err := client.Scan(opts)
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 4, len(devices))
+
+// 	// since scan responses are sorted by default, the devices order should be
+// 	// consistent.
+// 	tempDevice1 := devices[0]
+// 	assert.Equal(t, "89fd576d-462c-53be-bcb6-7870e70c304a", tempDevice1.ID)
+// 	assert.Empty(t, tempDevice1.Alias)
+// 	assert.Equal(t, "Synse Temperature Sensor 2", tempDevice1.Info)
+// 	assert.Equal(t, "temperature", tempDevice1.Type)
+// 	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", tempDevice1.Plugin)
+// 	assert.Equal(t, 3, len(tempDevice1.Tags))
+// 	assert.Equal(t, "foo/bar", tempDevice1.Tags[0])
+// 	assert.Equal(t, "system/id:89fd576d-462c-53be-bcb6-7870e70c304a", tempDevice1.Tags[1])
+// 	assert.Equal(t, "system/type:temperature", tempDevice1.Tags[2])
+
+// 	tempDevice2 := devices[1]
+// 	assert.Equal(t, "9907bdfa-75e1-5af5-8385-87184f356b22", tempDevice2.ID)
+// 	assert.Empty(t, tempDevice2.Alias)
+// 	assert.Equal(t, "Synse Temperature Sensor 1", tempDevice2.Info)
+// 	assert.Equal(t, "temperature", tempDevice2.Type)
+// 	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", tempDevice2.Plugin)
+// 	assert.Equal(t, 3, len(tempDevice2.Tags))
+// 	assert.Equal(t, "foo/bar", tempDevice2.Tags[0])
+// 	assert.Equal(t, "system/id:9907bdfa-75e1-5af5-8385-87184f356b22", tempDevice2.Tags[1])
+// 	assert.Equal(t, "system/type:temperature", tempDevice2.Tags[2])
+
+// 	tempDevice3 := devices[2]
+// 	assert.Equal(t, "b9324904-385b-581d-b790-5e53eaabfd20", tempDevice3.ID)
+// 	assert.Equal(t, "emulator-temp", tempDevice3.Alias)
+// 	assert.Equal(t, "Synse Temperature Sensor 3", tempDevice3.Info)
+// 	assert.Equal(t, "temperature", tempDevice3.Type)
+// 	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", tempDevice3.Plugin)
+// 	assert.Equal(t, 2, len(tempDevice3.Tags))
+// 	assert.Equal(t, "system/id:b9324904-385b-581d-b790-5e53eaabfd20", tempDevice3.Tags[0])
+// 	assert.Equal(t, "system/type:temperature", tempDevice3.Tags[1])
+
+// 	ledDevice := devices[3]
+// 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", ledDevice.ID)
+// 	assert.Equal(t, "emulator-led", ledDevice.Alias)
+// 	assert.Equal(t, "Synse LED", ledDevice.Info)
+// 	assert.Equal(t, "led", ledDevice.Type)
+// 	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", ledDevice.Plugin)
+// 	assert.Equal(t, 3, len(ledDevice.Tags))
+// 	assert.Equal(t, "foo/bar", ledDevice.Tags[0])
+// 	assert.Equal(t, "system/id:f041883c-cf87-55d7-a978-3d3103836412", ledDevice.Tags[1])
+// 	assert.Equal(t, "system/type:led", ledDevice.Tags[2])
+// }
+
+// FIXME - got a 500 error response from synse server at 2019-08-29T15:59:15Z,
+// saying An unexpected error occurred., with context: tags() argument after *
+// must be an iterable, not NoneType
+// func TestIntegrationWebSocket_Tags(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	opts := scheme.TagsOptions{}
+// 	tags, err := client.Tags(opts)
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 3, len(tags))
+// 	assert.Equal(t, "foo/bar", tags[0])
+// 	assert.Equal(t, "system/type:led", tags[1])
+// 	assert.Equal(t, "system/type:temperature", tags[2])
+// }
+
+func TestIntegrationWebSocket_Info(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	device, err := client.Info("f041883c-cf87-55d7-a978-3d3103836412")
+	assert.NoError(t, err)
+	assert.NotEmpty(t, device.Timestamp)
+	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", device.ID)
+	assert.Equal(t, "led", device.Type)
+	assert.Equal(t, "4032ffbe-80db-5aa5-b794-f35c88dff85c", device.Plugin)
+	assert.Equal(t, "Synse LED", device.Info)
+	assert.Equal(t, "emulator-led", device.Alias)
+	assert.Equal(t, map[string]string{"model": "emul8-led"}, device.Metadata)
+	assert.Equal(t, "rw", device.Capabilities.Mode)
+	assert.Equal(t, 0, len(device.Capabilities.Write.Actions))
+	assert.Equal(t, 3, len(device.Tags))
+	assert.Equal(t, "foo/bar", device.Tags[0])
+	assert.Equal(t, "system/id:f041883c-cf87-55d7-a978-3d3103836412", device.Tags[1])
+	assert.Equal(t, "system/type:led", device.Tags[2])
+	assert.Equal(t, 2, len(device.Outputs))
+	assert.Equal(t, 0, device.SortIndex)
+
+	stateOutput := device.Outputs[0]
+	assert.Equal(t, "state", stateOutput.Name)
+	assert.Equal(t, "state", stateOutput.Type)
+	assert.Equal(t, 0, stateOutput.Precision)
+	assert.Equal(t, 0.0, stateOutput.ScalingFactor)
+
+	colorOutput := device.Outputs[1]
+	assert.Equal(t, "color", colorOutput.Name)
+	assert.Equal(t, "color", colorOutput.Type)
+	assert.Equal(t, 0, colorOutput.Precision)
+	assert.Equal(t, 0.0, colorOutput.ScalingFactor)
+}
+
+// FIXME - got a 500 error response from synse server at 2019-08-29T16:05:38Z,
+// saying An unexpected error occurred., with context: object of type
+// 'NoneType' has no len()
+// func TestIntegrationWebSocket_Read(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	opts := scheme.ReadOptions{}
+// 	readings, err := client.Read(opts)
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 5, len(readings))
+
+// 	counts := countDeviceType(readings)
+// 	assert.Equal(t, 2, counts["led"])
+// 	assert.Equal(t, 3, counts["temperature"])
+
+// 	for _, read := range readings {
+// 		if read.DeviceType == "led" {
+// 			assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", read.Device)
+// 			assert.NotEmpty(t, read.Timestamp)
+// 			assert.Contains(t, []string{"state", "color"}, read.Type)
+// 			assert.Empty(t, read.Unit)
+// 			assert.Contains(t, []string{"off", "000000"}, read.Value)
+// 			assert.Empty(t, read.Context)
+// 		} else if read.DeviceType == "temperature" {
+// 			assert.Contains(t, []string{"89fd576d-462c-53be-bcb6-7870e70c304a", "9907bdfa-75e1-5af5-8385-87184f356b22", "b9324904-385b-581d-b790-5e53eaabfd20"}, read.Device)
+// 			assert.NotEmpty(t, read.Timestamp)
+// 			assert.Equal(t, "temperature", read.Type)
+// 			assert.Equal(t, "celsius", read.Unit.Name)
+// 			assert.Equal(t, "C", read.Unit.Symbol)
+// 			assert.NotEmpty(t, read.Value)
+// 			assert.Empty(t, read.Context)
+// 		} else {
+// 			t.Error("unexpected reading device type in response")
+// 		}
+// 	}
+// }
+
+func TestIntegrationWebSocket_ReadDevice(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	readings, err := client.ReadDevice("f041883c-cf87-55d7-a978-3d3103836412")
+	assert.NoError(t, err)
+	assert.Equal(t, 2, len(readings))
+
+	stateRead := readings[0]
+	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", stateRead.Device)
+	assert.NotEmpty(t, stateRead.Timestamp)
+	assert.Equal(t, "state", stateRead.Type)
+	assert.Equal(t, "led", stateRead.DeviceType)
+	assert.Empty(t, stateRead.Unit)
+	assert.Equal(t, "off", stateRead.Value)
+	assert.Empty(t, stateRead.Context)
+
+	colorRead := readings[1]
+	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", colorRead.Device)
+	assert.NotEmpty(t, colorRead.Timestamp)
+	assert.Equal(t, "color", colorRead.Type)
+	assert.Equal(t, "led", colorRead.DeviceType)
+	assert.Empty(t, colorRead.Unit)
+	assert.Equal(t, "000000", colorRead.Value)
+	assert.Empty(t, colorRead.Context)
+}
+
+func TestIntegrationWebSocket_ReadCache(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test")
+	}
+
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	err = client.Open()
+	assert.NoError(t, err)
+
+	defer func() {
+		err = client.Close()
+		assert.NoError(t, err)
+	}()
+
+	opts := scheme.ReadCacheOptions{}
+	readings := make(chan *scheme.Read, 1)
+
+	go func() {
+		err := client.ReadCache(opts, readings)
+		assert.NoError(t, err)
+	}()
+
+	for {
+		var done bool
+		select {
+		case read, open := <-readings:
+			if !open {
+				done = true
+				break
+			}
+
+			if read.DeviceType == "led" {
+				assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", read.Device)
+				assert.NotEmpty(t, read.Timestamp)
+				assert.Contains(t, []string{"state", "color"}, read.Type)
+				assert.Empty(t, read.Unit)
+				assert.Contains(t, []string{"off", "000000"}, read.Value)
+				assert.Empty(t, read.Context)
+			} else if read.DeviceType == "temperature" {
+				assert.Contains(t, []string{"89fd576d-462c-53be-bcb6-7870e70c304a", "9907bdfa-75e1-5af5-8385-87184f356b22", "b9324904-385b-581d-b790-5e53eaabfd20"}, read.Device)
+				assert.NotEmpty(t, read.Timestamp)
+				assert.Equal(t, "temperature", read.Type)
+				assert.Equal(t, "celsius", read.Unit.Name)
+				assert.Equal(t, "C", read.Unit.Symbol)
+				assert.NotEmpty(t, read.Value)
+				assert.Empty(t, read.Context)
+			} else {
+				t.Error("unexpected reading device type in response")
+			}
+
+		case <-time.After(2 * time.Second):
+			// if the test does not complete after 2s, error.
+			t.Fatal("timeout: failed getting readcache data from channel")
+		}
+
+		if done {
+			break
+		}
+	}
+}

--- a/synse/websocket_integration_test.go
+++ b/synse/websocket_integration_test.go
@@ -625,3 +625,43 @@ func TestIntegrationWebSocket_ReadCache(t *testing.T) {
 // 	assert.Empty(t, colorWrite.Context.Transaction)
 // 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", colorWrite.Device)
 // }
+
+// FIXME - WriteAsync and WriteSync need to be fixed first before enabling
+// this.
+// func TestIntegrationWebSocket_Transaction(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	transactions, err := client.Transactions()
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 4, len(transactions))
+
+// 	for _, id := range transactions {
+// 		transaction, err := client.Transaction(id)
+// 		assert.NoError(t, err)
+// 		assert.NotEmpty(t, transaction.ID)
+// 		assert.NotEmpty(t, transaction.Created)
+// 		assert.NotEmpty(t, transaction.Updated)
+// 		assert.Equal(t, "30s", transaction.Timeout)
+// 		assert.Equal(t, "DONE", transaction.Status)
+// 		assert.Contains(t, []string{"state", "color"}, transaction.Context.Action)
+// 		assert.Contains(t, []string{"on", "blink", "ffffff", "0f0f0f"}, transaction.Context.Data)
+// 		assert.Empty(t, transaction.Message)
+// 		assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", transaction.Device)
+// 	}
+// }

--- a/synse/websocket_integration_test.go
+++ b/synse/websocket_integration_test.go
@@ -526,3 +526,102 @@ func TestIntegrationWebSocket_ReadCache(t *testing.T) {
 		}
 	}
 }
+
+// FIXME - got a 500 error response from synse server at 2019-08-30T10:27:42Z,
+// saying An unexpected error occurred., with context: Object of type 'bytes'
+// func TestIntegrationWebSocket_WriteAsync(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	writeData := []scheme.WriteData{
+// 		{Action: "state", Data: "on"},
+// 		{Action: "color", Data: "ffffff"},
+// 	}
+// 	writes, err := client.WriteAsync("f041883c-cf87-55d7-a978-3d3103836412", writeData)
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 2, len(writes))
+
+// 	stateWrite := writes[0]
+// 	assert.NotEmpty(t, stateWrite.ID)
+// 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", stateWrite.Device)
+// 	assert.Equal(t, "state", stateWrite.Context.Action)
+// 	assert.Equal(t, "on", stateWrite.Context.Data)
+// 	assert.Empty(t, stateWrite.Context.Transaction)
+// 	assert.Equal(t, "30s", stateWrite.Timeout)
+
+// 	colorWrite := writes[1]
+// 	assert.NotEmpty(t, colorWrite.ID)
+// 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", colorWrite.Device)
+// 	assert.Equal(t, "color", colorWrite.Context.Action)
+// 	assert.Equal(t, "ffffff", colorWrite.Context.Data)
+// 	assert.Empty(t, colorWrite.Context.Transaction)
+// 	assert.Equal(t, "30s", colorWrite.Timeout)
+// }
+
+// FIXME - got a 500 error response from synse server at 2019-08-30T10:27:42Z,
+// saying An unexpected error occurred., with context: Object of type 'bytes'
+// is not JSON serializable
+// func TestIntegrationWebSocket_WriteSync(t *testing.T) {
+// 	if testing.Short() {
+// 		t.Skip("skipping integration test")
+// 	}
+
+// 	client, err := NewWebSocketClientV3(&Options{
+// 		Address: "localhost:5000",
+// 	})
+// 	assert.NotNil(t, client)
+// 	assert.NoError(t, err)
+
+// 	err = client.Open()
+// 	assert.NoError(t, err)
+
+// 	defer func() {
+// 		err = client.Close()
+// 		assert.NoError(t, err)
+// 	}()
+
+// 	writeData := []scheme.WriteData{
+// 		{Action: "state", Data: "blink"},
+// 		{Action: "color", Data: "0f0f0f"},
+// 	}
+// 	writes, err := client.WriteSync("f041883c-cf87-55d7-a978-3d3103836412", writeData)
+// 	assert.NoError(t, err)
+// 	assert.Equal(t, 2, len(writes))
+
+// 	stateWrite := writes[0]
+// 	assert.NotEmpty(t, stateWrite.ID)
+// 	assert.NotEmpty(t, stateWrite.Created)
+// 	assert.NotEmpty(t, stateWrite.Updated)
+// 	assert.Equal(t, "30s", stateWrite.Timeout)
+// 	assert.Equal(t, "DONE", stateWrite.Status)
+// 	assert.Equal(t, "state", stateWrite.Context.Action)
+// 	assert.Equal(t, "blink", stateWrite.Context.Data)
+// 	assert.Empty(t, stateWrite.Context.Transaction)
+// 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", stateWrite.Device)
+
+// 	colorWrite := writes[1]
+// 	assert.NotEmpty(t, colorWrite.ID)
+// 	assert.NotEmpty(t, colorWrite.Created)
+// 	assert.NotEmpty(t, colorWrite.Updated)
+// 	assert.Equal(t, "30s", colorWrite.Timeout)
+// 	assert.Equal(t, "DONE", colorWrite.Status)
+// 	assert.Equal(t, "color", colorWrite.Context.Action)
+// 	assert.Equal(t, "0f0f0f", colorWrite.Context.Data)
+// 	assert.Empty(t, colorWrite.Context.Transaction)
+// 	assert.Equal(t, "f041883c-cf87-55d7-a978-3d3103836412", colorWrite.Device)
+// }

--- a/synse/websocket_test.go
+++ b/synse/websocket_test.go
@@ -374,7 +374,7 @@ func TestWebSocketClientV3_Plugins_200(t *testing.T) {
 	in := `
 {
    "id":1,
-   "event":"response/plugin",
+   "event":"response/plugin_summary",
    "data":[
       {
          "description":"a plugin with emulated devices and data",
@@ -472,7 +472,7 @@ func TestWebSocketClientV3_Plugin_200(t *testing.T) {
 	in := `
 {
    "id":1,
-   "event":"response/plugin",
+   "event":"response/plugin_info",
    "data":{
       "active":true,
       "id":"1b714cf2-cc56-5c36-9741-fd6a483b5f10",
@@ -910,7 +910,7 @@ func TestWebSocketClientV3_Info_200(t *testing.T) {
 	in := `
 {
    "id":1,
-   "event":"response/device",
+   "event":"response/device_info",
    "data":{
       "timestamp":"2019-03-20T17:37:07Z",
       "id":"1b714cf2-cc56-5c36-9741-fd6a483b5f10",

--- a/synse/websocket_test.go
+++ b/synse/websocket_test.go
@@ -1693,7 +1693,7 @@ func TestWebSocketClientV3_Transactions_200(t *testing.T) {
 	in := `
 {
    "id":1,
-   "event":"response/transaction",
+   "event":"response/transaction_list",
    "data":[
       "56a32eba-1aa6-4868-84ee-fe01af8b2e6b",
       "56a32eba-1aa6-4868-84ee-fe01af8b2e6c",
@@ -1766,7 +1766,7 @@ func TestWebSocketClientV3_Transaction_200(t *testing.T) {
 	in := `
 {
    "id":1,
-   "event":"response/transaction",
+   "event":"response/transaction_info",
    "data":{
       "id":"56a32eba-1aa6-4868-84ee-fe01af8b2e6b",
       "timeout":"10s",


### PR DESCRIPTION
This PR:
- make integration tests for http and websocket client run separately 
- update websocket latest scheme
- add initial integration tests for websocket (#63)

Note that some of these tests are commented because of 500 response from server.