### PR TITLE
initial implementation for stream readings (ws only)

### DIFF
--- a/examples/read_stream/main.go
+++ b/examples/read_stream/main.go
@@ -1,0 +1,53 @@
+package main
+
+// This file provides an example of how to initiate and terminate a stream of
+// readings using the WebSocket client. In this example, readings are printed
+// out to console. After 6 seconds, the stream is terminated and the program
+// will exit.
+
+import (
+	"fmt"
+	"log"
+	"time"
+
+	"github.com/vapor-ware/synse-client-go/synse"
+	"github.com/vapor-ware/synse-client-go/synse/scheme"
+)
+
+func main() {
+	c, err := synse.NewWebSocketClientV3(&synse.Options{
+		Address: "localhost:5000",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	defer c.Close()
+	if err := c.Open(); err != nil {
+		log.Fatal(err)
+	}
+
+	stop := make(chan struct{}, 1)
+	readings := make(chan *scheme.Read)
+	defer close(readings)
+
+	go func() {
+		if err := c.ReadStream(scheme.ReadStreamOptions{}, readings, stop); err != nil {
+			log.Fatal(err)
+		}
+	}()
+
+	fmt.Println("-- Streaming Readings --")
+	timeout := time.After(6 * time.Second)
+	for {
+		select {
+		case r := <-readings:
+			fmt.Printf("• %+v\n", r)
+
+		case <-timeout:
+			fmt.Println("-- terminating stream --")
+			close(stop)
+			return
+		}
+	}
+}

--- a/synse/http.go
+++ b/synse/http.go
@@ -211,7 +211,7 @@ func (c *httpClient) ReadDevice(id string) ([]*scheme.Read, error) {
 	return *out, nil
 }
 
-// ReadCache returns stream reading data from the registered plugins.
+// ReadCache returns cached reading data from the registered plugins.
 func (c *httpClient) ReadCache(opts scheme.ReadCacheOptions, out chan<- *scheme.Read) error {
 	defer close(out)
 	errScheme := new(scheme.Error)
@@ -230,6 +230,11 @@ func (c *httpClient) ReadCache(opts scheme.ReadCacheOptions, out chan<- *scheme.
 		out <- read
 	}
 	return nil
+}
+
+// ReadStream returns a stream of current reading data from the registered plugins.
+func (c *httpClient) ReadStream(opts scheme.ReadStreamOptions, out chan<- *scheme.Read, stop chan struct{}) error {
+	return errors.New("Streamed readings is not currently supported via the HTTP API")
 }
 
 // WriteAsync writes data to a device, in an asynchronous manner.

--- a/synse/scheme/event.go
+++ b/synse/scheme/event.go
@@ -89,6 +89,12 @@ type RequestReadCache struct {
 	Data      ReadCacheOptions `json:"data" yaml:"data" mapstructure:"data"`
 }
 
+// RequestReadStream describes a scheme for the request/read_stream event.
+type RequestReadStream struct {
+	EventMeta `mapstructure:",squash"`
+	Data      ReadStreamOptions `json:"data" yaml:"data" mapstructure:"data"`
+}
+
 // RequestWrite describes a scheme for request/write_async and
 // request/write_sync event.
 type RequestWrite struct {

--- a/synse/scheme/read_stream.go
+++ b/synse/scheme/read_stream.go
@@ -1,0 +1,8 @@
+package scheme
+
+// ReadStreamOptions describe the query parameters for the streamed readings endpoint.
+type ReadStreamOptions struct {
+	Ids  []string `json:"ids,omitempty" yaml:"ids,omitempty" mapstructure:"ids"`
+	Stop bool     `json:"stop,omitempty" yaml:"stop,omitempty" mapstructure:"stop"`
+	Tags []string `json:"tags,omitempty" yaml:"tags,omitempty" mapstructure:"tags"`
+}

--- a/synse/synse.go
+++ b/synse/synse.go
@@ -51,8 +51,12 @@ type Client interface {
 	// specified in ReadOptions.
 	ReadDevice(string) ([]*scheme.Read, error)
 
-	// ReadCache returns stream reading data from the registered plugins.
+	// ReadCache returns cached reading data from the registered plugins.
 	ReadCache(scheme.ReadCacheOptions, chan<- *scheme.Read) error
+
+	// ReadStream returns a stream of current reading data from the
+	// registered plugins.
+	ReadStream(scheme.ReadStreamOptions, chan<- *scheme.Read, chan struct{}) error
 
 	// WriteAsync writes data to a device, in an asynchronous manner.
 	WriteAsync(string, []scheme.WriteData) ([]*scheme.Write, error)


### PR DESCRIPTION
This PR:
- adds a `ReadStream` function to the client interface
- adds support for reading a stream of reading data for the websocket client only (not yet supported in http api)
- creates a helper function for parsing response messages, since it is used by both the stream request and regular request

fixes #76


I don't think that this PR is quite ready yet, but opening for initial review. The issue that I'd like to solve prior to calling this ready is figuring out how to stop reading from a stream. Right now it just goes indefinitely until the program is exited. I think there are a number of ways this could be done...

#### exit callback

this would change the function signature
```go
ReadStream(scheme.ReadStreamOptions, chan<- *scheme.Read, exit func() bool) error
```

where the `exit` func would be called in the loop and when set to `true`, it would exit

```go
exiter = func() bool {
    time.Sleep(5 * time.Second)
    return true
}
```

#### exit channel - bool

this would change the function signature
```go
ReadStream(scheme.ReadStreamOptions, chan<- *scheme.Read, exit chan bool) error
```

where the `exit` channel would be read from in the loop and when passed `true`, it would exit

```go
exiter <- true
```

#### exit channel - closer

this would change the function signature
```go
ReadStream(scheme.ReadStreamOptions, chan<- *scheme.Read, exit chan struct{}) error
```

where the `exit` channel would be checked in the loop to see if it is open/closed. if closed, it would exit the loop.

```go
close(exiter)
```

-----------------

I feel like there probably are other approaches too, but the three above are the ones that came to me immediately. I think any option could work, so I guess its just a matter of semantics. The first option might be the least flexible, so I'd probably stick with one of the other two, but I'm interested in opinions/ideas