### PR TITLE
bugfix: check if websocket connection exists before attempting to close it

### DIFF
--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -105,12 +105,18 @@ func (c *websocketClient) Open() error {
 // Close closes the websocket connection between the client and Synse Server.
 // It's up to the user to close the connection after finish using it.
 func (c *websocketClient) Close() error {
-	// FIXME (etd): I think this will panic if close is called before connect.
-	err := c.connection.WriteMessage(websocket.CloseMessage, websocket.FormatCloseMessage(websocket.CloseNormalClosure, ""))
-	if err != nil {
-		return errors.Wrap(err, "failed to close the connection gracefully")
+	if c.connection != nil {
+		err := c.connection.WriteMessage(
+			websocket.CloseMessage,
+			websocket.FormatCloseMessage(
+				websocket.CloseNormalClosure,
+				"",
+			),
+		)
+		if err != nil {
+			return errors.Wrap(err, "failed to close the connection gracefully")
+		}
 	}
-
 	return nil
 }
 

--- a/synse/websocket_test.go
+++ b/synse/websocket_test.go
@@ -71,6 +71,16 @@ func TestNewWebSocketClientV3_ValidAddressAndTimeout(t *testing.T) {
 	assert.NoError(t, err)
 }
 
+func TestWebSocketClientV3_Close(t *testing.T) {
+	client, err := NewWebSocketClientV3(&Options{
+		Address: "localhost:5000",
+	})
+	assert.NoError(t, err)
+
+	err = client.Close()
+	assert.NoError(t, err)
+}
+
 func TestWebSocketClientV3_Status_200(t *testing.T) {
 	in := `
 {


### PR DESCRIPTION
This PR:
- checks whether there the websocket connection exists before attempting to close it. prior to this update, calling close before the connection was setup would lead to a panic for nil pointer reference

fixes #88