### PR TITLE
allow enabling tls without custom certs

### DIFF
--- a/synse/http.go
+++ b/synse/http.go
@@ -73,11 +73,13 @@ func createHTTPClient(opts *Options) (*resty.Client, error) {
 		return nil, err
 	}
 
+	if cert != nil {
+		client = client.SetCertificates(*cert)
+	}
+
 	// NOTE - refer to #24. If not disable linting, a warning will happen:
 	// TLS InsecureSkipVerify may be true.,HIGH,LOW (gosec)
-	return client.
-		SetCertificates(cert).
-		SetTLSClientConfig(&tls.Config{InsecureSkipVerify: opts.TLS.SkipVerify}), nil // nolint
+	return client.SetTLSClientConfig(&tls.Config{InsecureSkipVerify: opts.TLS.SkipVerify}), nil // nolint
 }
 
 // Open opens the connection between the client and Synse Server. This fulfils

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -32,8 +32,8 @@ func TestNewHTTPClientV3_NoTLSCertificates(t *testing.T) {
 			Enabled: true,
 		},
 	})
-	assert.Nil(t, client)
-	assert.Error(t, err)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
 }
 
 func TestNewHTTPClientV3_defaults(t *testing.T) {

--- a/synse/utils.go
+++ b/synse/utils.go
@@ -31,17 +31,18 @@ func setDefaults(opts *Options) error {
 }
 
 // setTLS registers the certificates with configured options.
-func setTLS(opts *Options) (tls.Certificate, error) {
+func setTLS(opts *Options) (*tls.Certificate, error) {
 	if opts.TLS.CertFile == "" && opts.TLS.KeyFile == "" {
-		return tls.Certificate{}, errors.New("no certificates are specified")
+		// return &tls.Certificate{}, errors.New("no certificates are specified")
+		return nil, nil
 	}
 
 	cert, err := tls.LoadX509KeyPair(opts.TLS.CertFile, opts.TLS.KeyFile)
 	if err != nil {
-		return tls.Certificate{}, errors.Wrap(err, "failed to set client certificates")
+		return nil, errors.Wrap(err, "failed to set client certificates")
 	}
 
-	return cert, nil
+	return &cert, nil
 }
 
 // buildURL builds up a complete URL from given scheme, host and path.

--- a/synse/websocket.go
+++ b/synse/websocket.go
@@ -79,10 +79,15 @@ func createWebSocketClient(opts *Options) (*websocket.Dialer, error) {
 		return nil, err
 	}
 
+	certs := []tls.Certificate{}
+	if cert != nil {
+		certs = append(certs, *cert)
+	}
+
 	return &websocket.Dialer{
 		HandshakeTimeout: opts.WebSocket.HandshakeTimeout,
 		TLSClientConfig: &tls.Config{
-			Certificates: []tls.Certificate{cert},
+			Certificates: certs,
 
 			// NOTE - refer to #24. If not disable linting, a warning will happen:
 			// TLS InsecureSkipVerify may be true.,HIGH,LOW (gosec)

--- a/synse/websocket_test.go
+++ b/synse/websocket_test.go
@@ -33,8 +33,8 @@ func TestNewWebSocketClientV3_NoTLSCertificates(t *testing.T) {
 			Enabled: true,
 		},
 	})
-	assert.Nil(t, client)
-	assert.Error(t, err)
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
 }
 
 func TestNewWebSocketClientV3_defaults(t *testing.T) {
@@ -1627,7 +1627,6 @@ func TestWebSocketClientV3_ReadStream_200(t *testing.T) {
 			// If the test does not complete after 2s, error.
 			//t.Fatal("timeout: failed getting read stream data from channel")
 			done = true
-			break
 		}
 
 		if done {


### PR DESCRIPTION
This PR:
- updates the TLS config to allow TLS to be enabled without setting a custom cert/key. In this case, it uses the default system certs/CA.