### PR TITLE
Allow synse HTTP client to work with redirects

### DIFF
--- a/synse/config.go
+++ b/synse/config.go
@@ -29,6 +29,9 @@ type HTTPOptions struct {
 
 	// Retry specifies the options for retry mechanism.
 	Retry RetryOptions
+
+	// Redirects specifies the max number of allowed http redirects
+	Redirects int `default:"5"`
 }
 
 // WebSocketOptions is the config options for websocket protocol.

--- a/synse/http_test.go
+++ b/synse/http_test.go
@@ -52,6 +52,7 @@ func TestNewHTTPClientV3_defaults(t *testing.T) {
 	assert.Empty(t, client.GetOptions().TLS.KeyFile)
 	assert.False(t, client.GetOptions().TLS.Enabled)
 	assert.False(t, client.GetOptions().TLS.SkipVerify)
+	assert.Equal(t, 5, client.GetOptions().HTTP.Redirects)
 }
 
 func TestNewHTTPClientV3_ValidAddress(t *testing.T) {
@@ -59,6 +60,17 @@ func TestNewHTTPClientV3_ValidAddress(t *testing.T) {
 		Address: "localhost:5000",
 	})
 	assert.NotNil(t, client)
+	assert.NoError(t, err)
+}
+
+func TestNewHTTPClientV3_AddressWithHTTPS(t *testing.T) {
+	client, err := NewHTTPClientV3(&Options{
+		Address: "https://example.com",
+	})
+	assert.NotNil(t, client)
+	assert.NoError(t, err)
+
+	_, err = client.Status()
 	assert.NoError(t, err)
 }
 


### PR DESCRIPTION
This PR allows the synse HTTP client to work with redirects so that it can read synse server via proxy.

It also checks for TLS if the scheme is written into the address instead of config.

Signed-off-by: Sam Foo <sam.foo@vapor.io>